### PR TITLE
Update setup.py classifiers and CHANGELOG for Wagtail 5.2 and Python …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Wagtail 5.2 and Python 3.12 upgrade
+
 ## 1.0.0 (2023-07-25)
 
 - Wagtail upgrades [v3 -> v5.0](https://github.com/torchbox-forks/wagtail_clear_cache/pull/1)

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Intended Audience :: Developers",
         "Topic :: Internet :: WWW/HTTP",
         "Topic :: Internet :: WWW/HTTP :: Dynamic Content",


### PR DESCRIPTION
## [Wagtail 5.2 release notes](https://docs.wagtail.org/en/stable/releases/5.2.html)

Changes:
- [Update setup.py classifiers and CHANGELOG for Wagtail 5.2 and Python 3.12](https://github.com/torchbox-forks/wagtail_clear_cache/commit/8567bd9cd4ed12230409fda512b7c39af86e0687) 